### PR TITLE
Fix: logo being chopped off in header

### DIFF
--- a/app/assets/stylesheets/styles/_logo.scss
+++ b/app/assets/stylesheets/styles/_logo.scss
@@ -76,6 +76,7 @@
   .lamp-post-logo {
     width: 100%;
     height: 290px;
+    overflow: visible;
 
     .logo-path { fill: $highlight; }
 


### PR DESCRIPTION
@catheraaine another please.

The logo was getting chopped on very small screens (350 wide-ish) This should fix that.